### PR TITLE
Set an explicit width limit on Inspect.Algebra.

### DIFF
--- a/lib/mix/tasks/es6_maps/format.ex
+++ b/lib/mix/tasks/es6_maps/format.ex
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Es6Maps.Format do
       escape: false,
       locals_without_parens: opts.locals_without_parens
     )
-    |> Inspect.Algebra.format(:infinity)
+    |> Inspect.Algebra.format(98)
     |> then(&File.write!(filepath, &1))
   end
 

--- a/test/es6_maps_test/test/format_test.exs
+++ b/test/es6_maps_test/test/format_test.exs
@@ -147,5 +147,30 @@ defmodule Es6MapsTest.Format do
         """
       end
       '''
+
+    test_formatting "comments are not moved around",
+      original: """
+      defmodule Test do
+        use LoremIpsum,
+          lorem: [LoremIpsum],
+          ipsum: [
+            # Lorem Ipsum Dolor
+            LoremIpsumDolorSitAmetConsequaturAdipisciElit,
+            LoremIpsumDolorSitAmetConsequaturAdipisciElit,
+            LoremIpsumDolorSitAmetConsequaturAdipisciElit
+          ]
+      end
+      """
+
+    test_formatting "multiline list literals are not single-lined",
+      original: """
+      def test do
+        [
+          1,
+          2,
+          3
+        ]
+      end
+      """
   end
 end


### PR DESCRIPTION
An explicit limit of 98 (equal to the value Mix formatter uses) prevents various formatting glitches that happened e.g. around comments and multiline lists.