### PR TITLE
Rewrite instrumentation on top of `:elixir.string_to_tokens/5`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+# 1.0.0 (Unreleased)
+
+## Highlights
+
+### Changed base implementation
+
+`es6_maps` now instruments `:elixir.string_to_tokens/5` instead of `:elixir_map.expand_map/4`.
+
+This is a much less internal API, making it unlikely to break `es6_maps` in the future.  
+It also plays much better with the broader Elixir ecosystem that's likely to read Elixir code via the tokenizer.
+In particular, anything that reads AST will see the "expanded"/"vanilla" map syntax.
+
+For example, previously this wouldn't print a nice assertion diff in ExUnit tests, instead failing inside ExUnit diffing logic:
+
+```elixir
+assert %MyStruct{hello, foo: 1} = %MyStruct{foo: 10}
+```
+
+Now, it displays a proper diff as ExUnit's code sees the expanded version.

--- a/README.md
+++ b/README.md
@@ -144,10 +144,11 @@ For example in the code below, the first map will be formatted to the shorthand 
 
 ## How does it work?
 
-`es6_maps` replaces in runtime the Elixir compiler's `elixir_map` module.
-The module's `expand_map/4` function is wrapped with a function that replaces map keys `%{k}` as if they were `%{k: k}`.
+`es6_maps` replaces in runtime the Elixir compiler's `:elixir` module.
+The module's `string_to_tokens/5` function is wrapped with a function that replaces map keys `%{k}` as if they were `%{k: k}`.
 After `es6_maps` runs as one of the Mix compilers, the Elixir compiler will use the replaced functions to compile the rest of the code.
 
 > [!IMPORTANT]
+>
 > By the nature of this solution it's tightly coupled to the internal Elixir implementation.
-> The current version of `es6_maps` should work for Elixir 1.15, 1.16, 1.17 and the upcoming 1.18 version, but may break in the future.
+> The current version of `es6_maps` should work for Elixir 1.15, 1.16, 1.17, 1.18 and the upcoming 1.19 version, but may break in the future.

--- a/test/es6_maps_test/.formatter.exs
+++ b/test/es6_maps_test/.formatter.exs
@@ -1,0 +1,6 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  plugins: [Es6Maps.Formatter],
+  locals_without_parens: [test_formatting: 2]
+]

--- a/test/es6_maps_test/test/es6_maps_test.exs
+++ b/test/es6_maps_test/test/es6_maps_test.exs
@@ -7,4 +7,78 @@ defmodule Es6MapsTest.Es6Maps do
   end
 
   doctest_file("../../README.md")
+
+  describe ":elixir.string_to_tokens/5" do
+    test "map expand" do
+      assert {:ok, tokens} = :elixir.string_to_tokens(~c"%{x}", 0, 0, "", [])
+
+      assert [
+               {:%{}, _},
+               {:"{", _},
+               {:kw_identifier, _, :x},
+               {:identifier, _, :x},
+               {:"}", _}
+             ] = tokens
+    end
+
+    test "map failure to expand when `es6_maps: false`" do
+      assert {:ok, tokens} = :elixir.string_to_tokens(~c"%{x}", 0, 0, "", es6_maps: false)
+
+      assert [
+               {:%{}, _},
+               {:"{", _},
+               {:identifier, _, :x},
+               {:"}", _}
+             ] = tokens
+    end
+
+    test "struct expand" do
+      assert {:ok, tokens} = :elixir.string_to_tokens(~c"%S{x}", 0, 0, "", [])
+
+      assert [
+               {:%, _},
+               {:alias, _, :S},
+               {:"{", _},
+               {:kw_identifier, _, :x},
+               {:identifier, _, :x},
+               {:"}", _}
+             ] = tokens
+    end
+
+    test "struct failure to expand when `es6_maps: false`" do
+      assert {:ok, tokens} = :elixir.string_to_tokens(~c"%S{x}", 0, 0, "", es6_maps: false)
+
+      assert [
+               {:%, _},
+               {:alias, _, :S},
+               {:"{", _},
+               {:identifier, _, :x},
+               {:"}", _}
+             ] = tokens
+    end
+  end
+
+  describe "ExUnit assertions" do
+    test "assert structs" do
+      foo = 1
+      assert %MyStruct{hello, foo: 2} = %MyStruct{foo, bar: 3}
+      _ = hello
+    rescue
+      e in ExUnit.AssertionError ->
+        assert Macro.to_string(e.left) == "%Es6MapsTest.Es6Maps.MyStruct{hello: hello, foo: 2}"
+
+        assert Macro.to_string(e.right) ==
+                 "%Es6MapsTest.Es6Maps.MyStruct{hello: nil, foo: 1, bar: 3}"
+    end
+
+    test "assert maps" do
+      foo = 1
+      assert %{hello, foo: 2} = %{foo, bar: 3}
+      _ = hello
+    rescue
+      e in ExUnit.AssertionError ->
+        assert Macro.to_string(e.left) == "%{hello: hello, foo: 2}"
+        assert Macro.to_string(e.right) == "%{foo: 1, bar: 3}"
+    end
+  end
 end

--- a/test/es6_maps_test/test/format_test.exs
+++ b/test/es6_maps_test/test/format_test.exs
@@ -18,6 +18,26 @@ defmodule Es6MapsTest.Format do
       end
       """
 
+    test_formatting "already formatted map is not reformatted",
+      original: """
+      def test(var) do
+        %{grepme, b, c: 1} = var
+        var
+      end
+      """,
+      formatted: """
+      def test(var) do
+        %{grepme, b, c: 1} = var
+        var
+      end
+      """,
+      reverted: """
+      def test(var) do
+        %{grepme: grepme, b: b, c: 1} = var
+        var
+      end
+      """
+
     test_formatting "has its keys moved to the front when reformatting to shorthand",
       original: """
       def test(var) do


### PR DESCRIPTION
This is a more stable API that's unlikely to change.
It also plays well with the broader Elixir ecosystem - since anything
reading Elixir code will at the very least tokenize it, the tools will
see a "valid" expanded form of the code.

Tags: feature
Topic: string-to-tokens
Labels: feature