### PR TITLE
Runtime instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,14 @@ assert %MyStruct{hello, foo: 1} = %MyStruct{foo: 10}
 ```
 
 Now, it displays a proper diff as ExUnit's code sees the expanded version.
+
+### Runtime instrumentation
+
+`es6_maps` now includes an `Application` implementation that will enable its functionality in runtime.
+
+Simply remove the `runtime: false` parameter from the dependency definition in `Mix.exs` to enable hot-loading es6-style maps in production:
+
+```diff
+-      {:es6_maps, "~> 0.2", runtime: false}
++      {:es6_maps, "~> 1.0"}
+```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ end
 
 def deps do
   [
-    {:es6_maps, "~> 0.2.2", runtime: false}
+    {:es6_maps, "~> 0.2.2"}
   ]
 end
 ```

--- a/lib/mix/tasks/compile/es6_maps.ex
+++ b/lib/mix/tasks/compile/es6_maps.ex
@@ -1,0 +1,11 @@
+defmodule Mix.Tasks.Compile.Es6Maps do
+  @moduledoc false
+
+  use Mix.Task.Compiler
+
+  def run(_args) do
+    :ok = Application.ensure_loaded(:es6_maps)
+    :ok = Es6Maps.load()
+    :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Es6Maps.MixProject do
   end
 
   def application do
-    []
+    [mod: {Es6Maps, []}]
   end
 
   defp deps do

--- a/test/es6_maps_test/mix.exs
+++ b/test/es6_maps_test/mix.exs
@@ -21,7 +21,7 @@ defmodule Es6MapsTest.MixProject do
 
   defp deps do
     [
-      {:es6_maps, path: "../..", runtime: false}
+      {:es6_maps, path: "../.."}
     ]
   end
 


### PR DESCRIPTION
Implement Application module that loads es6_maps on start.
This allows for hot-loading es6_maps in production.