### PR TITLE
Add ElixirLS plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,10 @@ Simply remove the `runtime: false` parameter from the dependency definition in `
 -      {:es6_maps, "~> 0.2", runtime: false}
 +      {:es6_maps, "~> 1.0"}
 ```
+
+### ElixirLS plugin
+
+`es6_maps` now includes a plugin for ElixirLS that will ensure it's loaded in the language server.
+
+This feature builds on top of both the base implementation change & runtime instrumentation.
+ElixirLS will see and analyze the expanded code.

--- a/lib/es6_maps/elixir_sense/plugin.ex
+++ b/lib/es6_maps/elixir_sense/plugin.ex
@@ -1,0 +1,15 @@
+if match?({:module, _}, Code.ensure_compiled(ElixirLS.LanguageServer.Plugin)) do
+  defmodule Es6Maps.ElixirSense.Plugin do
+    @moduledoc false
+    @behaviour ElixirLS.LanguageServer.Plugin
+
+    alias ElixirLS.LanguageServer.Plugins.ModuleStore
+
+    @impl ElixirLS.LanguageServer.Plugin
+    def setup(context) do
+      module_store = ModuleStore.ensure_compiled(context, Es6Maps)
+      Es6Maps.load()
+      module_store
+    end
+  end
+end


### PR DESCRIPTION
Loads `es6_maps` inside ElixirLS.
This allows ElixirLS to see and analyze the expanded code.